### PR TITLE
add EMM env and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 # ansible
 *.retry
+
+# pycharm
+.idea

--- a/README.md
+++ b/README.md
@@ -1,14 +1,40 @@
 # ansible-minimal
-basic ansible deployment for non-hq machines
 
-Usage example:
+Basic ansible deployment for non-hq machines.
+
+## Usage example:
+
+The following will bootstrap a set of dimagi users on a new machine.
+
+**Create enviroment files**
+
+See `environments/emm` for examples.
+
+**Setup ansible user password**
+
+First choose a password. Then generate a sha-512 hash:
 
 ```
-ansible-playbook --extra-vars="ansible_user_password_sha_512=$ANSIBLE_HASH" -u root --ask-pass --diff -i 192.168.1.2, bootstrap.yml
+mkpasswd -m sha-512 [my secret password]
+```
+
+
+Next put this password hash in your environment (make sure to keep the quotes!):
+
+```
+export ANSIBLE_HASH='[output of previous command]'
+```
+
+**Finally, run the bootstrap command**
+
+You should replace the references to the `emm` environment with the files you created.
+
+```
+ansible-playbook -u root --ask-pass --extra-vars="ansible_user_password_sha_512=$ANSIBLE_HASH" -i environments/emm/inventory.ini -e @environments/emm/public.yml bootstrap.yml --diff
 ```
 
 After ansible user has been setup:
 
 ```
-ansible-playbook -u ansible --ask-become-pass --diff --extra-vars="ansible_user_password_sha_512=$ANSIBLE_HASH" -i 192.168.1.2, bootstrap.yml
+ansible-playbook -u ansible --ask-become-pass -i environments/emm/inventory.ini -e @environments/emm/public.yml bootstrap.yml --diff
 ```

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1,6 +1,5 @@
 - name: Ansible minimal
   hosts: all
-  gather_facts: no
   become: true
   gather_facts: true
   vars_files:

--- a/environments/emm/inventory.ini
+++ b/environments/emm/inventory.ini
@@ -1,0 +1,6 @@
+[emm-gateway]
+emm.dimagi.com
+
+
+[pg_backup:children]
+emm-gateway

--- a/environments/emm/public.yml
+++ b/environments/emm/public.yml
@@ -34,11 +34,6 @@ dev_users:
 postgres_s3: True
 backup_postgres: dump
 aws_region: us-east-1
-secrets:
-  POSTGRES_USERS:
-    replication:
-      username: emm
-      password: secret  # needs to be changed locally to work
 localsettings:
   AMAZON_S3_ACCESS_KEY: test_access  # needs to be changed locally to work
   AMAZON_S3_SECRET_KEY: test_secret  # needs to be changed locally to work

--- a/environments/emm/public.yml
+++ b/environments/emm/public.yml
@@ -1,0 +1,44 @@
+SITE_HOST: 'emm.dimagi.com'
+deploy_env: emm-gateway
+cchq_user: web
+authorized_keys_dir: ./commcare-cloud/environments/_authorized_keys/
+# users to allow login - still need to make this shared with commcare-cloud
+dev_users:
+  present:
+    - astone
+    - biyeun
+    - cellowitz
+    - ctsims
+    - czue
+    - dmiller
+    - droberts
+    - esoergel
+    - frener
+    - gbova
+    - gcapalbo
+    - jemord
+    - jroth
+    - jschweers
+    - jwilson
+    - mkangia
+    - npellegrino
+    - nhooper
+    - nsharma
+    - pvaidyanathan
+    - sgoyal
+    - skelly
+    - sravfeyn
+    - wpride
+  absent: []
+# pg backup variables
+postgres_s3: True
+backup_postgres: dump
+aws_region: us-east-1
+secrets:
+  POSTGRES_USERS:
+    replication:
+      username: emm
+      password: secret  # needs to be changed locally to work
+localsettings:
+  AMAZON_S3_ACCESS_KEY: test_access  # needs to be changed locally to work
+  AMAZON_S3_SECRET_KEY: test_secret  # needs to be changed locally to work


### PR DESCRIPTION
@dannyroberts I played around with https://github.com/dimagi/commcare-cloud/pull/1488#issuecomment-376261365 a bit and wasn't able to get anything working. feel free to try as well if you'd like.

I think we will need to start adding `envs` here if we plan on actually using it to bootstrap other machines. also open to other options on this, but figuring out a systematic way to do this is out of scope for what I'm trying to do. if we don't want these changes in this repo, I'll just leave the branch up and link to it from the `emm` docs so it's clear how to make changes (this works for us for what we need to do now)